### PR TITLE
Optimize --table-re

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 # Changes log for Test::CPAN::Meta
 
+0.44    20th April 2014
+        - optimized the --table-re option to exclude
+          tables before comparing them as this would
+          cause significant slowdowns in databases
+          with lots of tables.
+
 0.43    6th October 2011
         - fix missing fields in CPAN meta-data
 

--- a/META.json
+++ b/META.json
@@ -31,19 +31,19 @@
    "provides" : {
       "MySQL::Diff" : {
          "file" : "lib/MySQL/Diff.pm",
-         "version" : "0.43"
+         "version" : "0.44"
       },
       "MySQL::Diff::Database" : {
          "file" : "lib/MySQL/Diff/Database.pm",
-         "version" : "0.43"
+         "version" : "0.44"
       },
       "MySQL::Diff::Table" : {
          "file" : "lib/MySQL/Diff/Table.pm",
-         "version" : "0.43"
+         "version" : "0.44"
       },
       "MySQL::Diff::Utils" : {
          "file" : "lib/MySQL/Diff/Utils.pm",
-         "version" : "0.43"
+         "version" : "0.44"
       }
    },
    "release_status" : "stable",
@@ -59,5 +59,5 @@
          "url" : "http://github.com/aspiers/mysqldiff"
       }
    },
-   "version" : "0.43"
+   "version" : "0.44"
 }

--- a/META.yml
+++ b/META.yml
@@ -15,16 +15,16 @@ name: MySQL-Diff
 provides:
   MySQL::Diff:
     file: lib/MySQL/Diff.pm
-    version: 0.43
+    version: 0.44
   MySQL::Diff::Database:
     file: lib/MySQL/Diff/Database.pm
-    version: 0.43
+    version: 0.44
   MySQL::Diff::Table:
     file: lib/MySQL/Diff/Table.pm
-    version: 0.43
+    version: 0.44
   MySQL::Diff::Utils:
     file: lib/MySQL/Diff/Utils.pm
-    version: 0.43
+    version: 0.44
 requires:
   Carp: 0
   File::Slurp: 0
@@ -35,4 +35,4 @@ resources:
   homepage: http://adamspiers.org/computing/mysqldiff/
   license: http://dev.perl.org/licenses/
   repository: http://github.com/aspiers/mysqldiff
-version: 0.43
+version: 0.44

--- a/lib/MySQL/Diff/Table.pm
+++ b/lib/MySQL/Diff/Table.pm
@@ -32,7 +32,7 @@ Parses a table definition into component parts.
 use warnings;
 use strict;
 
-our $VERSION = '0.43';
+our $VERSION = '0.44';
 
 # ------------------------------------------------------------------------------
 # Libraries

--- a/lib/MySQL/Diff/Utils.pm
+++ b/lib/MySQL/Diff/Utils.pm
@@ -17,7 +17,7 @@ Currently contains the debug message handling routines.
 use warnings;
 use strict;
 
-our $VERSION = '0.43';
+our $VERSION = '0.44';
 
 # ------------------------------------------------------------------------------
 # Libraries

--- a/t/all.t
+++ b/t/all.t
@@ -452,8 +452,8 @@ my @tests = (keys %tests); #keys %tests
       my $diff = MySQL::Diff->new(%$opts, %debug);
       isa_ok($diff,'MySQL::Diff');
 
-      my $db1 = get_db($db1_defs, 1);
-      my $db2 = get_db($db2_defs, 2);
+      my $db1 = get_db($db1_defs, 1, $opts->{'table-re'});
+      my $db2 = get_db($db2_defs, 2, $opts->{'table-re'});
 
       my $d1 = $diff->register_db($db1, 1);
       my $d2 = $diff->register_db($db2, 2);
@@ -487,7 +487,7 @@ my @tests = (keys %tests); #keys %tests
       is_deeply($diffs, $expected, ".. expected differences for $test");
 
       # Now test that $diffs correctly patches $db1_defs to $db2_defs.
-      my $patched = get_db($db1_defs . "\n" . $diffs, 1);
+      my $patched = get_db($db1_defs . "\n" . $diffs, 1, $opts->{'table-re'});
       $diff->register_db($patched, 1);
       is_deeply($diff->diff(), '', ".. patched differences for $test");
     }
@@ -495,7 +495,7 @@ my @tests = (keys %tests); #keys %tests
 
 
 sub get_db {
-    my ($defs, $num) = @_;
+    my ($defs, $num, $table_re) = @_;
 
     note("defs=$defs");
 
@@ -503,7 +503,7 @@ sub get_db {
     open(TMP, ">$file") or die "open: $!";
     print TMP $defs;
     close(TMP);
-    my $db = MySQL::Diff::Database->new(file => $file, auth => { user => $TEST_USER });
+    my $db = MySQL::Diff::Database->new(file => $file, auth => { user => $TEST_USER }, 'table-re' => $table_re);
     unlink $file;
     return $db;
 }


### PR DESCRIPTION
The previous method would fetch all the data in the mysqldump and then throw away the tables that did not match the --table-re.  This change excludes the tables from the mysqldump in order to avoid the extra work.  In my production database with 5000+ tables mysqldiff was taking about 5 minutes comparing tables outside the regex.  It now tables about 2 seconds with this change.
