### PR TITLE
Bug fix - added auth_args method to MySQL::Diff::Database.

### DIFF
--- a/lib/MySQL/Diff/Database.pm
+++ b/lib/MySQL/Diff/Database.pm
@@ -191,6 +191,11 @@ sub available_dbs {
 # ------------------------------------------------------------------------------
 # Private Methods
 
+sub auth_args {
+  my $self = shift;
+  return _auth_args_string();
+}
+
 sub _canonicalise_file {
     my ($self, $file) = @_;
 

--- a/t/regression-rt-79976.t
+++ b/t/regression-rt-79976.t
@@ -1,0 +1,18 @@
+#!/usr/bin/perl -w
+use strict;
+
+use Test::More tests => 4;
+
+# checks for regression to https://rt.cpan.org/Public/Bug/Display.html?id=79976
+
+BEGIN {
+    use_ok('MySQL::Diff::Database');
+}
+
+can_ok 'MySQL::Diff::Database', 'auth_args';
+
+my $db = new_ok 'MySQL::Diff::Database' => [ db => 'foo' ];
+
+can_ok $db, 'auth_args';
+
+__END__


### PR DESCRIPTION
RT 79976: bin/mysqldiff was calling MySQL::Diff::Database->auth_args,
which did not exist. The stated workaround in the RT bug DB was to use
_auth_args_string directly. The solution was to just create a wrapper
method called auth_args. Added a unit test for regression checking.

Bug URL - https://rt.cpan.org/Public/Bug/Display.html?id=79976
