### PR TITLE
Bug fix - fixed undefined value in duplicate field error message, M::D::...

### DIFF
--- a/lib/MySQL/Diff/Table.pm
+++ b/lib/MySQL/Diff/Table.pm
@@ -183,7 +183,7 @@ sub _parse {
 
         if (/^(KEY|UNIQUE(?: KEY)?)\s+(\S+?)(?:\s+USING\s+(?:BTREE|HASH|RTREE))?\s*\((.*)\)$/) {
             my ($type, $key, $val) = ($1, $2, $3);
-            croak "index '$key' duplicated in table '$name'\n"
+            croak "index '$key' duplicated in table '$self->{name}'\n"
                 if $self->{indices}{$key};
             $self->{indices}{$key} = $val;
             $self->{unique}{$key} = 1   if($type =~ /unique/i);
@@ -193,7 +193,7 @@ sub _parse {
 
         if (/^(FULLTEXT(?:\s+KEY|INDEX)?)\s+(\S+?)\s*\((.*)\)$/) {
             my ($type, $key, $val) = ($1, $2, $3);
-            croak "FULLTEXT index '$key' duplicated in table '$name'\n"
+            croak "FULLTEXT index '$key' duplicated in table '$self->{name}'\n"
                 if $self->{fulltext}{$key};
             $self->{indices}{$key} = $val;
             $self->{fulltext}{$key} = 1;
@@ -209,7 +209,7 @@ sub _parse {
 
         if (/^(\S+)\s*(.*)/) {
             my ($field, $fdef) = ($1, $2);
-            croak "definition for field '$field' duplicated in table '$name'\n"
+            croak "definition for field '$field' duplicated in table '$self->{name}'\n"
                 if $self->{fields}{$field};
             $self->{fields}{$field} = $fdef;
             debug(4,"got field def '$field': $fdef");

--- a/t/regression-rt-77002.t
+++ b/t/regression-rt-77002.t
@@ -1,0 +1,46 @@
+#!/usr/bin/perl -w
+use strict;
+
+use Test::More tests => 4;
+
+# checks for regression to https://rt.cpan.org/Public/Bug/Display.html?id=77002 
+
+BEGIN {
+    use_ok('MySQL::Diff::Table');
+}
+
+my $table_def = <<END;
+CREATE TABLE table_1 (
+  id INT(11) NOT NULL auto_increment,
+  foreign_id INT(11) NOT NULL, # another random comment
+  field BLOB,
+  PRIMARY KEY (id)
+);
+END
+
+my $table = new_ok 'MySQL::Diff::Table' => [ def => $table_def ];
+
+ok $table->{name} eq 'table_1', 'ensuring table name parsed properly';
+
+my $duplicate_field_table_def = <<END;
+CREATE TABLE table_1 (
+  id INT(11) NOT NULL auto_increment,
+  id INT(11) NOT NULL auto_increment,
+  foreign_id INT(11) NOT NULL, # another random comment
+  field BLOB,
+  PRIMARY KEY (id)
+);
+END
+
+# construct directly, outside new_ok
+eval {
+    my $table2 = MySQL::Diff::Table->new( def => $duplicate_field_table_def );
+};
+my $expected = qq{definition for field 'id' duplicated in table 'table_1'};
+my @g        = split /\n/, $@;
+my $got      = $g[0];
+
+ok $got eq $expected,
+  'ensuring table name returned in duplicate field name error';
+
+__END__


### PR DESCRIPTION
...Table.

RT 77002: lib/MySQL/Diff/Table.pm was improperly reporting the table
name when throwing an exception related to their being duplicate
field/column names during the parsing of the SQL table definition.

Fixed reference to object instance field and create a unit test to
check for regressions.
