### PR TITLE
Support Older Create table spec

### DIFF
--- a/lib/MySQL/Diff/Table.pm
+++ b/lib/MySQL/Diff/Table.pm
@@ -181,7 +181,7 @@ sub _parse {
             next;
         }
 
-        if (/^(KEY|UNIQUE(?: KEY)?)\s+(\S+?)(?:\s+USING\s+(?:BTREE|HASH|RTREE))?\s*\((.*)\)$/) {
+        if (/^(KEY|UNIQUE(?: KEY)?)\s+(\S+?)(?:\s+USING\s+(?:BTREE|HASH|RTREE))?\s*\((.*)\)(?:\s+USING\s+(?:BTREE|HASH|RTREE))?$/) {
             my ($type, $key, $val) = ($1, $2, $3);
             croak "index '$key' duplicated in table '$name'\n"
                 if $self->{indices}{$key};


### PR DESCRIPTION
The Create table spec for MySql 5.0 allowed for the index type to come either before or after the index column names
https://dev.mysql.com/doc/refman/5.0/en/create-table.html