### PR TITLE
Adding auto increment column fails with error 1075

### DIFF
--- a/lib/MySQL/Diff/Table.pm
+++ b/lib/MySQL/Diff/Table.pm
@@ -126,6 +126,10 @@ Returns 1 if given field is used as unique index field, otherwise returns 0.
 
 Returns 1 if given field is used as fulltext index field, otherwise returns 0.
 
+=item * is_auto_inc
+
+Returns 1 if given field is defined as an auto increment field, otherwise returns 0.
+
 =back
 
 =cut
@@ -144,6 +148,7 @@ sub isa_primary     { my $self = shift; return $_[0] && $self->{primary}{$_[0]} 
 sub isa_index       { my $self = shift; return $_[0] && $self->{indices}{$_[0]}  ? 1 : 0; }
 sub is_unique       { my $self = shift; return $_[0] && $self->{unique}{$_[0]}   ? 1 : 0; }
 sub is_fulltext     { my $self = shift; return $_[0] && $self->{fulltext}{$_[0]} ? 1 : 0; }
+sub is_auto_inc     { my $self = shift; return $_[0] && $self->{auto_inc}{$_[0]} ? 1 : 0; }
 
 # ------------------------------------------------------------------------------
 # Private Methods
@@ -223,6 +228,9 @@ sub _parse {
                 if $self->{fields}{$field};
             $self->{fields}{$field} = $fdef;
             debug(4,"got field def '$field': $fdef");
+            next unless $fdef =~ /\s+AUTO_INCREMENT\b/;
+            $self->{auto_inc}{$field} = 1;
+            debug(4,"got AUTO_INCREMENT field '$field'");
             next;
         }
 

--- a/t/all.t
+++ b/t/all.t
@@ -102,6 +102,29 @@ CREATE TABLE baz (
   KEY (firstname, surname)
 ) DEFAULT CHARACTER SET utf8;
 ',
+
+  qux1 => '
+CREATE TABLE qux (
+  age INT
+) DEFAULT CHARACTER SET utf8;
+',
+
+  qux2 => '
+CREATE TABLE qux (
+  id  INT NOT NULL AUTO_INCREMENT,
+  age INT,
+  PRIMARY KEY (id)
+) DEFAULT CHARACTER SET utf8;
+',
+
+  qux3 => '
+CREATE TABLE qux (
+  id  INT NOT NULL AUTO_INCREMENT,
+  age INT,
+  UNIQUE KEY (id)
+) DEFAULT CHARACTER SET utf8;
+',
+
 );
 
 my %tests = (
@@ -424,6 +447,38 @@ ALTER TABLE baz ADD INDEX firstname (firstname,surname);
 
 ALTER TABLE baz DROP INDEX firstname; # was INDEX (firstname,surname)
 ALTER TABLE baz ADD UNIQUE firstname (firstname,surname);
+',
+  ],
+
+  'add auto increment primary key' =>
+  [
+    {},
+    $tables{qux1},
+    $tables{qux2},
+    '## mysqldiff <VERSION>
+##
+## Run on <DATE>
+##
+## --- file: tmp.db1
+## +++ file: tmp.db2
+
+ALTER TABLE qux ADD COLUMN id int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY;
+',
+  ],
+
+  'add auto increment unique key' =>
+  [
+    {},
+    $tables{qux1},
+    $tables{qux3},
+    '## mysqldiff <VERSION>
+##
+## Run on <DATE>
+##
+## --- file: tmp.db1
+## +++ file: tmp.db2
+
+ALTER TABLE qux ADD COLUMN id int(11) NOT NULL AUTO_INCREMENT UNIQUE KEY;
 ',
   ],
 );


### PR DESCRIPTION
Issue-30. Two statements are used to add an AUTO_INCREMENT primary key
column, and this causes a 1075 error: `Incorrect table definition; there
can be only one auto column and it must be defined as a key`

This revision adds checks for auto increment fields.  If a PRIMARY or
UNIQUE key has been defined for an auto increment field, it is appended
to the field definition instead of being created as a separate alter
statement.