### PR TITLE
--keep-old-columns option

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 # Changes log for Test::CPAN::Meta
+Unreleased
+        - added "--keep-old-columns" option that disables emitting DROP COLUMN
+          commands
 
 0.50    21 July 2016
         - fix bug with 0.49's new feature (SilentScope)

--- a/bin/mysqldiff
+++ b/bin/mysqldiff
@@ -89,6 +89,10 @@ only output changes for tables in both databases
 
 don't output DROP TABLE commands
 
+=item C<-c,  --keep-old-columns>
+
+don't output DROP COLUMN commands
+
 =item C<-n,  --no-old-defs>
 
 suppress comments describing old definitions
@@ -203,7 +207,8 @@ use MySQL::Diff;
 
 my %opts = ();
 GetOptions(\%opts, "help|?", "debug|d:i", "apply|A", "batch-apply|B",
-           "keep-old-tables|k", "no-old-defs|n", "only-both|o", "table-re|t=s",
+           "keep-old-tables|k", "keep-old-columns|c", "no-old-defs|n",
+           "only-both|o", "table-re|t=s",
            "host|h=s", "port|P=s", "socket|s=s", "user|u=s", "password|p:s",
            "host1=s",  "port1=s",  "socket1=s",  "user1=s",  "password1:s",
            "host2=s",  "port2=s",  "socket2=s",  "user2=s",  "password2:s",
@@ -243,6 +248,7 @@ Options:
   -l,  --list-tables         output the list off all used tables
   -o,  --only-both           only output changes for tables in both databases
   -k,  --keep-old-tables     don't output DROP TABLE commands
+  -c,  --keep-old-columns    don't output DROP COLUMN commands
   -n,  --no-old-defs         suppress comments describing old definitions
   -t,  --table-re=REGEXP     restrict comparisons to tables matching REGEXP
   -i,  --tolerant            ignore DEFAULT, AUTO_INCREMENT, COLLATE, and formatting changes

--- a/lib/MySQL/Diff.pm
+++ b/lib/MySQL/Diff.pm
@@ -239,7 +239,7 @@ sub _diff_fields {
                         push @changes, $change;
                     }
                 }
-            } else {
+            } elsif (!$self->{opts}{'keep-old-columns'}) {
                 debug(3,"field '$field' removed");
                 my $change = "ALTER TABLE $name1 DROP COLUMN $field;";
                 $change .= " # was $fields1->{$field}" unless $self->{opts}{'no-old-defs'};

--- a/t/all.t
+++ b/t/all.t
@@ -262,6 +262,23 @@ ALTER TABLE foo ADD COLUMN field blob;
 ',
   ],
 
+  'keep-old-columns' =>
+  [
+    { 'keep-old-columns' => 1 },
+    $tables{foo2} . $tables{bar1}, $tables{foo1},
+    '## mysqldiff <VERSION>
+##
+## Run on <DATE>
+## Options: keep-old-columns
+##
+## --- file: tmp.db1
+## +++ file: tmp.db2
+
+DROP TABLE bar;
+
+',
+  ],
+
   'table-re' =>
   [
     { 'table-re' => 'ba' },


### PR DESCRIPTION
This PR adds a new option, `keep-old-columns`, and an associated CLI flag, `--keep-old-columns`.  I would like to deploy `mysqldiff` in an environment where developers frequently switch from newer to older versions of the relevant codebase.  The `keep-old-columns` option is useful in this scenario because it permits moving to older versions of the database schema without losing data (all schema changes in this codebase are backwards-compatible).

Thanks in advance for your consideration!